### PR TITLE
fix: robust way of getting a function signature

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.lsp
 Title: Provides 'box' Compatibility for 'languageserver'
-Version: 0.1.1
+Version: 0.1.1.9001
 Authors@R:
   c(
     person("Ricardo Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# box.lsp (development version)
+
+* Handle long function signatures spanning across multiple lines.
+
 # box.lsp 0.1.1
 
 * Fixed one unit test on Windows that returns a different length of values.

--- a/R/box_lsp.R
+++ b/R/box_lsp.R
@@ -133,7 +133,12 @@ box_use_parser <- function(expr, action) {
 
         if (this_function != "...") {
           namespaced_function <- paste0(as.character(x[[2]]), "::", this_function)
-          signature <- deparse(eval(parse(text = namespaced_function, keep.source = TRUE)))[[1]]
+          function_expression <- eval(parse(text = namespaced_function, keep.source = TRUE))
+          function_signature <- setdiff(
+            deparse(function_expression),
+            deparse(body(function_expression))
+          )
+          signature <- trimws(gsub("\\s+", " ", x = paste(function_signature, collapse = "")))
           sym_name <- ifelse(this_alias == "", this_function, this_alias)
 
           process_module(sym_name, signature, action)


### PR DESCRIPTION
Issue #23 

## Description
Current implementation assumes that the function signature
will always go on one line. As pointed out in #23, this is not
always the case.

To improve the process, I suggest to explicitly extract
function signature by taking "anything that is not the body".

## Definition of Done
- [x] The change is thoroughly documented.
- [x] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [x] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
