### PR TITLE
Add check for installed box.lsp package in .Rprofile

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: box.lsp
 Title: Provides 'box' Compatibility for 'languageserver'
-Version: 0.1.2
+Version: 0.1.2.9001
 Authors@R:
   c(
     person("Ricardo Rodrigo", "Basa", role = c("aut", "cre"), email = "opensource+rodrigo@appsilon.com"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# box.lsp (development version)
+
+* Added a check for `box.lsp` before loading the box.lsp languageserver options. This was causing CI and Docker builds to fail.
+
 # box.lsp 0.1.2
 
 * Fixed critical bug that causes `languageserver` to crash: Handle long function signatures spanning across multiple lines. (@Gotfrid #23)

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,3 +1,7 @@
+# box.lsp 0.1.3
+
+This bugfix release addresses a bug that causes R CMD Check in CI and Docker builds to fail.
+
 # box.lsp 0.1.2
 
 This bugfix release addresses a critical bug that causes `languageserver` to crash.

--- a/inst/Rprofile.R
+++ b/inst/Rprofile.R
@@ -1,5 +1,7 @@
-options(
-  languageserver.parser_hooks = list(
-    "box::use" = box.lsp::box_use_parser
+if (nzchar(system.file(package = "box.lsp"))) {
+  options(
+    languageserver.parser_hooks = list(
+      "box::use" = box.lsp::box_use_parser
+    )
   )
-)
+}


### PR DESCRIPTION
*Have you read the [Contributing Guidelines](https://github.com/Appsilon/.github/blob/main/CONTRIBUTING.md)?*

Issue #28 

## How to test
1. Run `box.lsp::use_box_lsp()` to set up `.Rprofile`.
2. With `box.lsp` installed, test that auto-complete works.
3. `remove.packages("box.lsp")`
4. Restart R session or restart VSCode.
5. Test that auto-complete does not work.

## Definition of Done
- [ ] The change is thoroughly documented.
- [ ] The CI passes (`R CMD check`, linter, unit tests, spelling).
- [ ] Any generated files have been updated (e.g. `.Rd` files with `roxygen2::roxygenise()`)
